### PR TITLE
Add "CFBundleShortVersionString" plist key

### DIFF
--- a/Dotnet.Bundle/BundleAppTask.cs
+++ b/Dotnet.Bundle/BundleAppTask.cs
@@ -35,13 +35,16 @@ namespace Dotnet.Bundle
 
         [Required]
         public string CFBundleIconFile { get; set; }
-        
+
+        [Required]
+        public string CFBundleShortVersionString { get; set; } 
+
         [Required]
         public string NSPrincipalClass { get; set; }
         
         [Required]
         public bool NSHighResolutionCapable { get; set; }
-        
+
         public override bool Execute()
         {
             var builder = new StructureBuilder(this);

--- a/Dotnet.Bundle/PlistWriter.cs
+++ b/Dotnet.Bundle/PlistWriter.cs
@@ -47,6 +47,7 @@ namespace Dotnet.Bundle
                 WriteProperty(xmlWriter, nameof(_task.CFBundleSignature), _task.CFBundleSignature);
                 WriteProperty(xmlWriter, nameof(_task.CFBundleExecutable), _task.CFBundleExecutable);
                 WriteProperty(xmlWriter, nameof(_task.CFBundleIconFile), Path.GetFileName(_task.CFBundleIconFile));
+                WriteProperty(xmlWriter, nameof(_task.CFBundleShortVersionString), _task.CFBundleShortVersionString);
                 WriteProperty(xmlWriter, nameof(_task.NSPrincipalClass), _task.NSPrincipalClass);
                 WriteProperty(xmlWriter, nameof(_task.NSHighResolutionCapable), _task.NSHighResolutionCapable);
                 

--- a/Dotnet.Bundle/build/DotNet.Bundle.targets
+++ b/Dotnet.Bundle/build/DotNet.Bundle.targets
@@ -33,6 +33,8 @@
       <CFBundleIconFile Condition="'$(CFBundleIconFile)' == '' AND '$(TargetName)' != ''">$(TargetName).icns</CFBundleIconFile>
       <CFBundleIconFile Condition="'$(CFBundleIconFile)' == '' AND '$(TargetName)' == ''">none.icns</CFBundleIconFile>
 
+      <CFBundleShortVersionString Condition="'$(CFBundleVersion)' == ''">$(CFBundleVersion)</CFBundleShortVersionString>
+
       <NSPrincipalClass Condition="'$(NSPrincipalClass)' == ''">NSApplication</NSPrincipalClass>
       
       <NSHighResolutionCapable Condition="'$(NSHighResolutionCapable)' == ''" >true</NSHighResolutionCapable>
@@ -50,6 +52,7 @@
       CFBundleSignature="$(CFBundleSignature)"
       CFBundleExecutable="$(CFBundleExecutable)"
       CFBundleIconFile="$(CFBundleIconFile)"
+      CFBundleShortVersionString="$(CFBundleShortVersionString)"
       NSPrincipalClass="$(NSPrincipalClass)"
       NSHighResolutionCapable="$(NSHighResolutionCapable)"
       />


### PR DESCRIPTION
I noticed that the "CFBundleShortVersionString" didn't get added to the Info.plist file, so I added it