### PR TITLE
Fix CFBundlePackageType

### DIFF
--- a/DotNet.Bundle/build/DotNet.Bundle.targets
+++ b/DotNet.Bundle/build/DotNet.Bundle.targets
@@ -23,7 +23,7 @@
       <CFBundleVersion Condition="'$(CFBundleVersion)' == '' AND '$(Version)' != ''">$(Version)</CFBundleVersion>
       <CFBundleVersion Condition="'$(CFBundleVersion)' == '' AND '$(Version)' == ''">1.0.0</CFBundleVersion>
 
-      <CFBundlePackageType Condition="'$(CFBundlePackageType)' == ''">AAPL</CFBundlePackageType>
+      <CFBundlePackageType Condition="'$(CFBundlePackageType)' == ''">APPL</CFBundlePackageType>
 
       <CFBundleSignature Condition="'$(CFBundleSignature)' == ''">????</CFBundleSignature>
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Define properties to override default bundle values
     <CFBundleDisplayName>App Name</CFBundleDisplayName>
     <CFBundleIdentifier>com.example</CFBundleIdentifier>
     <CFBundleVersion>1.0.0</CFBundleVersion>
-    <CFBundlePackageType>AAPL</CFBundlePackageType>
+    <CFBundlePackageType>APPL</CFBundlePackageType>
     <CFBundleSignature>????</CFBundleSignature>
     <CFBundleExecutable>AppName</CFBundleExecutable>
     <CFBundleIconFile>AppName.icns</CFBundleIconFile> <!-- Will be copied from output directory -->


### PR DESCRIPTION
I don't know if it's a typo or anything, but [CFBundlePackageType](https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundlepackagetype) says `For apps, the code is APPL`. And the [Bundle Structures](https://developer.apple.com/library/archive/documentation/CoreFoundation/Conceptual/CFBundles/BundleTypes/BundleTypes.html) says `For applications, the value of this key is always the four-character string APPL.`